### PR TITLE
chore: migrate to cacheComponents with use cache + cacheLife

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,20 @@
 allowBuilds:
   sharp: true
+minimumReleaseAgeExclude:
+  - next
+  - '@next/env'
+  - '@next/swc-darwin-arm64'
+  - '@next/swc-darwin-x64'
+  - '@next/swc-linux-arm64-gnu'
+  - '@next/swc-linux-arm64-musl'
+  - '@next/swc-linux-x64-gnu'
+  - '@next/swc-linux-x64-musl'
+  - '@next/swc-win32-arm64-msvc'
+  - '@next/swc-win32-x64-msvc'
+  - '@typescript-eslint/typescript-estree'
+  - '@typescript-eslint/utils'
+  - '@typescript-eslint/types'
+  - '@typescript-eslint/scope-manager'
+  - '@typescript-eslint/project-service'
+  - '@typescript-eslint/tsconfig-utils'
+  - '@typescript-eslint/visitor-keys'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,19 +2,5 @@ allowBuilds:
   sharp: true
 minimumReleaseAgeExclude:
   - next
-  - '@next/env'
-  - '@next/swc-darwin-arm64'
-  - '@next/swc-darwin-x64'
-  - '@next/swc-linux-arm64-gnu'
-  - '@next/swc-linux-arm64-musl'
-  - '@next/swc-linux-x64-gnu'
-  - '@next/swc-linux-x64-musl'
-  - '@next/swc-win32-arm64-msvc'
-  - '@next/swc-win32-x64-msvc'
-  - '@typescript-eslint/typescript-estree'
-  - '@typescript-eslint/utils'
-  - '@typescript-eslint/types'
-  - '@typescript-eslint/scope-manager'
-  - '@typescript-eslint/project-service'
-  - '@typescript-eslint/tsconfig-utils'
-  - '@typescript-eslint/visitor-keys'
+  - '@next/*'
+  - '@typescript-eslint/*'

--- a/src/app/api/tmdb/[[...path]]/route.ts
+++ b/src/app/api/tmdb/[[...path]]/route.ts
@@ -1,5 +1,16 @@
 import { tmdbServerFetcherCore } from 'lib/services/tmdb/utils.server';
+import { cacheLife } from 'next/cache';
 import { type NextRequest, NextResponse } from 'next/server';
+
+async function fetchTmdbData(path: string, params: Record<string, string>) {
+  'use cache';
+  cacheLife('days');
+
+  return await tmdbServerFetcherCore({
+    params,
+    path,
+  });
+}
 
 export async function GET(
   request: NextRequest,
@@ -12,10 +23,7 @@ export async function GET(
 
   const requestPath = path && path.length > 0 ? `/${path.join('/')}` : '/';
 
-  const data = await tmdbServerFetcherCore({
-    params: queryParams,
-    path: requestPath,
-  });
+  const data = await fetchTmdbData(requestPath, queryParams);
 
   return NextResponse.json(data, {
     headers: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { getTVShowByListType } from 'lib/services/tmdb/tv/list/index.server';
 
 export default async function Page() {
   const [popularMovieData, popularTvShowData] = await Promise.all([
-    getMovieListServer({ revalidate: 43_200, section: 'popular' }),
+    getMovieListServer({ section: 'popular' }),
     getTVShowByListType('popular'),
   ]);
 

--- a/src/lib/services/tmdb/movie/credits/index.server.ts
+++ b/src/lib/services/tmdb/movie/credits/index.server.ts
@@ -1,9 +1,13 @@
 import { tmdbServerFetcherCore } from 'lib/services/tmdb/utils.server';
+import { cacheLife } from 'next/cache';
 
 import type { MovieCreditsResponse } from './types';
 
-export const getMovieCreditsServer = (id: number) =>
-  tmdbServerFetcherCore<MovieCreditsResponse>({
+export async function getMovieCreditsServer(id: number) {
+  'use cache';
+  cacheLife('weeks');
+
+  return await tmdbServerFetcherCore<MovieCreditsResponse>({
     path: `/movie/${id}/credits`,
-    reqInit: { next: { revalidate: 604_800 } },
   });
+}

--- a/src/lib/services/tmdb/movie/detail/index.server.ts
+++ b/src/lib/services/tmdb/movie/detail/index.server.ts
@@ -1,9 +1,13 @@
 import { tmdbServerFetcherCore } from 'lib/services/tmdb/utils.server';
+import { cacheLife } from 'next/cache';
 
 import type { MovieDetailResponse } from './types';
 
-export const getMovieDetailServer = (id: number) =>
-  tmdbServerFetcherCore<MovieDetailResponse>({
+export async function getMovieDetailServer(id: number) {
+  'use cache';
+  cacheLife('weeks');
+
+  return await tmdbServerFetcherCore<MovieDetailResponse>({
     path: `/movie/${id}`,
-    reqInit: { next: { revalidate: 604_800 } },
   });
+}

--- a/src/lib/services/tmdb/movie/list/index.server.ts
+++ b/src/lib/services/tmdb/movie/list/index.server.ts
@@ -1,23 +1,25 @@
 import { movieListEndpoint } from 'lib/services/tmdb/movie/list/utils';
 import { tmdbServerFetcherCore } from 'lib/services/tmdb/utils.server';
+import { cacheLife } from 'next/cache';
 
 import type { ListType, MovieListParams, MovieListResponse } from './types';
 
-export const getMovieListServer = ({
+export async function getMovieListServer({
   section = 'popular',
   params,
-  revalidate,
 }: {
   section: ListType;
   params?: MovieListParams;
-  revalidate?: number;
-}) =>
-  tmdbServerFetcherCore<MovieListResponse>({
+}) {
+  'use cache';
+  cacheLife('hours');
+
+  return await tmdbServerFetcherCore<MovieListResponse>({
     params,
     path: movieListEndpoint({
       query: params?.query,
       section,
       with_genres: params?.with_genres,
     }),
-    reqInit: { next: { revalidate } },
   });
+}

--- a/src/lib/services/tmdb/tv/detail/index.server.ts
+++ b/src/lib/services/tmdb/tv/detail/index.server.ts
@@ -1,9 +1,13 @@
 import { tmdbServerFetcherCore } from 'lib/services/tmdb/utils.server';
+import { cacheLife } from 'next/cache';
 
 import type { TvShowDetail } from './types';
 
-export const getTvShowDetail = (id: string) =>
-  tmdbServerFetcherCore<TvShowDetail>({
+export async function getTvShowDetail(id: string) {
+  'use cache';
+  cacheLife('weeks');
+
+  return await tmdbServerFetcherCore<TvShowDetail>({
     path: `/tv/${id}`,
-    reqInit: { next: { revalidate: 604_800 } },
   });
+}

--- a/src/lib/services/tmdb/tv/list/index.server.ts
+++ b/src/lib/services/tmdb/tv/list/index.server.ts
@@ -1,5 +1,6 @@
 import { TV_SHOW_SEARCH_RESOURCE_PATH } from 'lib/services/tmdb/tv/list/constants';
 import { tmdbServerFetcher } from 'lib/services/tmdb/utils.server';
+import { cacheLife } from 'next/cache';
 
 import type {
   SearchTVShowParams,
@@ -8,10 +9,15 @@ import type {
   TVShowListType,
 } from './types';
 
-export const getTVShowByListType = (
+export async function getTVShowByListType(
   listType: TVShowListType,
   params?: TVShowListParams
-) => tmdbServerFetcher<TVShowListResponse>(`/tv/${listType}`, params);
+) {
+  'use cache';
+  cacheLife('hours');
+
+  return await tmdbServerFetcher<TVShowListResponse>(`/tv/${listType}`, params);
+}
 
 export const getTVShowSearchResultList = (params: SearchTVShowParams) =>
   tmdbServerFetcher<TVShowListResponse>(TV_SHOW_SEARCH_RESOURCE_PATH, params);


### PR DESCRIPTION
## Summary
Migrate the TMDB data layer to Next.js 16.3 cacheComponents + partialPrefetching. Replace the removed `revalidate`/`dynamic` route-segment exports and `next: { revalidate }` fetch options with `'use cache'` + `cacheLife` at the TMDB data layer.

The config-side changes (next.config.ts cacheComponents/partialPrefetching, loading.tsx, removal of route-segment revalidate/dynamic exports) landed earlier in `880a697` on main. This PR contains the remaining data-layer migration.

## Changes
| File | What changed | Why |
|---|---|---|
| src/lib/services/tmdb/movie/credits/index.server.ts | ~ 'use cache' + cacheLife('weeks') | Restore ISR caching removed with revalidate exports |
| src/lib/services/tmdb/movie/detail/index.server.ts | ~ 'use cache' + cacheLife('weeks') | Same |
| src/lib/services/tmdb/movie/list/index.server.ts | ~ 'use cache' + cacheLife('hours') | Same |
| src/lib/services/tmdb/tv/detail/index.server.ts | ~ 'use cache' + cacheLife('weeks') | Same |
| src/lib/services/tmdb/tv/list/index.server.ts | ~ 'use cache' + cacheLife('hours') | Same |
| src/app/api/tmdb/[[...path]]/route.ts | ~ extracted fetchTmdbData with 'use cache' + cacheLife('days') | 'use cache' can't live in a route handler body |
| src/app/page.tsx | ~ dropped revalidate arg from getMovieListServer call | API no longer accepts revalidate |
| pnpm-workspace.yaml | + minimumReleaseAgeExclude | Clear pnpm policy violations |

## Testing
- pnpm check:turbo: 2/2 tasks pass (ultracite check, tsc --noEmit)
- pnpm build: passes, / static (1h revalidate), detail routes partial prerendered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved caching for movie, TV show, credits, details, lists, and TMDB requests.
  * Frequently accessed content now loads faster with optimized cache durations.
* **Reliability**
  * Standardized content retrieval behavior across movie and TV pages.
  * Reduced unnecessary repeated requests while preserving access to current popular content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->